### PR TITLE
Bump product version to 0.8.8 in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	<!-- Single source of truth for the product version, shared by all projects
 		 (Core, CLI, Web, and future desktop). Bump this once to version everything. -->
-	<Version>0.8.7</Version>
+	<Version>0.8.8</Version>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Bump product version to 0.8.8 in Directory.Build.props

Updated the product version in Directory.Build.props from 0.8.7 to 0.8.8 to ensure all dependent projects use the latest version.