### PR TITLE
Server Type to Enum and changed default server name

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	<!-- Single source of truth for the product version, shared by all projects
 		 (Core, CLI, Web, and future desktop). Bump this once to version everything. -->
-	<Version>0.8.8</Version>
+	<Version>0.8.9</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/spool-dat-torrent.cli/Commands/ServerTableRenderer.cs
+++ b/src/spool-dat-torrent.cli/Commands/ServerTableRenderer.cs
@@ -30,7 +30,7 @@ namespace SpoolDatTorrent.Cli.Commands
             {
                 table.AddRow(
                     Markup.Escape(s.Name),
-                    Markup.Escape(s.ClientType),
+                    Markup.Escape(s.ClientType.ToString()),
                     Markup.Escape(s.Host),
                     Markup.Escape(s.Username),
                     s.HasApiKey ? "[green]yes[/]" : "[grey]no[/]",

--- a/src/spool-dat-torrent.core/Commands/AddServerProfileCommand.cs
+++ b/src/spool-dat-torrent.core/Commands/AddServerProfileCommand.cs
@@ -34,7 +34,7 @@ namespace SpoolDatTorrent.Core.Commands
 
             _settings.TorrentServers[profileName] = new TorrentServerProfile
             {
-                ClientType = BitTorrentClientTypes.QBittorrent,
+                ClientType = BitTorrentClientType.QBittorrent,
                 Host = "http://localhost:8080",
                 Username = "admin",
                 Password = string.Empty,

--- a/src/spool-dat-torrent.core/Configuration/BitTorrentClientTypes.cs
+++ b/src/spool-dat-torrent.core/Configuration/BitTorrentClientTypes.cs
@@ -1,26 +1,42 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SpoolDatTorrent.Core.Configuration
 {
     /// <summary>
-    /// Central registry of supported BitTorrent client types. Used by the web UI to
-    /// populate the Client Type dropdown and referenced when instantiating a client.
-    /// Add new client types here in a single place so every host (web, CLI, desktop)
-    /// stays in sync.
+    /// Supported BitTorrent client types. Add new members here in a single place so every
+    /// host (web, CLI, desktop) stays in sync. Only qBittorrent is implemented today.
     /// </summary>
-    public static class BitTorrentClientTypes
+    public enum BitTorrentClientType
     {
-        public const string QBittorrent = "qBittorrent";
+        QBittorrent
+    }
 
-        /// <summary>Planned but not yet implemented; retained so the dropdown is forward-compatible.</summary>
-        public const string Deluge = "Deluge";
-
-        /// <summary>The canonical, ordered list of client types offered to the user.</summary>
-        public static readonly IReadOnlyList<string> All = new List<string>
+    /// <summary>
+    /// JSON converter for <see cref="BitTorrentClientType"/>. Serializes as a string so
+    /// config.json stays human-readable, and reads the string back to the enum member
+    /// (case-insensitive).
+    /// </summary>
+    public sealed class BitTorrentClientTypeConverter : JsonConverter<BitTorrentClientType>
+    {
+        public override BitTorrentClientType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            QBittorrent            
-        };
+            var value = reader.GetString();
+            foreach (BitTorrentClientType member in Enum.GetValues<BitTorrentClientType>())
+            {
+                if (string.Equals(member.ToString(), value, StringComparison.OrdinalIgnoreCase))
+                {
+                    return member;
+                }
+            }
+
+            throw new JsonException($"Unknown BitTorrent client type: '{value}'.");
+        }
+
+        public override void Write(Utf8JsonWriter writer, BitTorrentClientType value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString());
+        }
     }
 }

--- a/src/spool-dat-torrent.core/Configuration/GlobalSpoolSettings.cs
+++ b/src/spool-dat-torrent.core/Configuration/GlobalSpoolSettings.cs
@@ -7,7 +7,7 @@ namespace SpoolDatTorrent.Core.Configuration
 {
     public class GlobalSpoolSettings
     {
-        public string DefaultServerProfile { get; set; } = "LocalQBit";
+        public string DefaultServerProfile { get; set; } = "DefaultQBit";
         public Dictionary<string, TorrentServerProfile> TorrentServers { get; set; } = new();
 
         /// <summary>

--- a/src/spool-dat-torrent.core/Configuration/SettingsManager.cs
+++ b/src/spool-dat-torrent.core/Configuration/SettingsManager.cs
@@ -9,6 +9,13 @@ namespace SpoolDatTorrent.Core.Configuration
 {
     public static class SettingsManager
     {
+        /// <summary>Shared serializer options, including the client-type enum converter.</summary>
+        private static readonly JsonSerializerOptions _jsonOptions = new()
+        {
+            WriteIndented = true,
+            Converters = { new BitTorrentClientTypeConverter() }
+        };
+
         public static string GetSettingsPath()
         {
             var envPath = Environment.GetEnvironmentVariable("SPOOL_CONFIG_DIR");
@@ -76,7 +83,7 @@ namespace SpoolDatTorrent.Core.Configuration
             if (File.Exists(settingsPath))
             {
                 var json = File.ReadAllText(settingsPath);
-                var settings = JsonSerializer.Deserialize<GlobalSpoolSettings>(json) ?? CreateDefaultSettings();
+                var settings = JsonSerializer.Deserialize<GlobalSpoolSettings>(json, _jsonOptions) ?? CreateDefaultSettings();
                 DecryptSecrets(settings);
                 return settings;
             }
@@ -109,15 +116,14 @@ namespace SpoolDatTorrent.Core.Configuration
         public static void SaveSettings(GlobalSpoolSettings settings)
         {
             string settingsPath = GetSettingsPath();
-            var options = new JsonSerializerOptions { WriteIndented = true };
 
             // Serialize a deep copy with encrypted secrets so the in-memory object keeps
             // plaintext (the UI/engine read it) and isn't double-encrypted on the next save.
-            var copy = JsonSerializer.Deserialize<GlobalSpoolSettings>(JsonSerializer.Serialize(settings));
+            var copy = JsonSerializer.Deserialize<GlobalSpoolSettings>(JsonSerializer.Serialize(settings, _jsonOptions), _jsonOptions);
             if (copy != null)
             {
                 EncryptSecrets(copy);
-                File.WriteAllText(settingsPath, JsonSerializer.Serialize(copy, options));
+                File.WriteAllText(settingsPath, JsonSerializer.Serialize(copy, _jsonOptions));
             }
         }
 
@@ -163,10 +169,10 @@ namespace SpoolDatTorrent.Core.Configuration
             return new Dictionary<string, TorrentServerProfile>
             {
                 {
-                    "LocalQBit",
+                    "DefaultQBit",
                     new TorrentServerProfile
                     {
-                        ClientType = "qBittorrent",
+                        ClientType = BitTorrentClientType.QBittorrent,
                         Host = "http://localhost:8080",
                         Username = "admin",
                         Password = "",
@@ -190,8 +196,7 @@ namespace SpoolDatTorrent.Core.Configuration
 
             var defaultSettings = CreateDefaultSettings();
 
-            var options = new JsonSerializerOptions { WriteIndented = true };
-            var json = JsonSerializer.Serialize(defaultSettings, options);
+            var json = JsonSerializer.Serialize(defaultSettings, _jsonOptions);
 
             File.WriteAllText(settingsPath, json);
             Logger.Log($"⚙️ Created default configuration file at: {settingsPath}");
@@ -211,7 +216,7 @@ namespace SpoolDatTorrent.Core.Configuration
             if (File.Exists(settingsPath))
             {
                 var json = File.ReadAllText(settingsPath);
-                settings = JsonSerializer.Deserialize<GlobalSpoolSettings>(json) ?? new GlobalSpoolSettings();
+                settings = JsonSerializer.Deserialize<GlobalSpoolSettings>(json, _jsonOptions) ?? new GlobalSpoolSettings();
             }
             else
             {
@@ -229,7 +234,7 @@ namespace SpoolDatTorrent.Core.Configuration
 
             settings.TorrentServers[profileName] = new TorrentServerProfile
             {
-                ClientType = "ToBeSet",
+                ClientType = BitTorrentClientType.QBittorrent,
                 Host = "ToBeSet",
                 Username = string.Empty,
                 Password = string.Empty,
@@ -242,8 +247,7 @@ namespace SpoolDatTorrent.Core.Configuration
                 }
             };
 
-            var writeOptions = new JsonSerializerOptions { WriteIndented = true };
-            File.WriteAllText(settingsPath, JsonSerializer.Serialize(settings, writeOptions));
+            File.WriteAllText(settingsPath, JsonSerializer.Serialize(settings, _jsonOptions));
 
             return profileName;
         }
@@ -261,7 +265,7 @@ namespace SpoolDatTorrent.Core.Configuration
             }
 
             var json = File.ReadAllText(settingsPath);
-            var settings = JsonSerializer.Deserialize<GlobalSpoolSettings>(json) ?? new GlobalSpoolSettings();
+            var settings = JsonSerializer.Deserialize<GlobalSpoolSettings>(json, _jsonOptions) ?? new GlobalSpoolSettings();
 
             if (!settings.TorrentServers.Remove(profileName))
             {
@@ -275,8 +279,7 @@ namespace SpoolDatTorrent.Core.Configuration
                 settings.DefaultServerProfile = settings.TorrentServers.Keys.FirstOrDefault() ?? string.Empty;
             }
 
-            var writeOptions = new JsonSerializerOptions { WriteIndented = true };
-            File.WriteAllText(settingsPath, JsonSerializer.Serialize(settings, writeOptions));
+            File.WriteAllText(settingsPath, JsonSerializer.Serialize(settings, _jsonOptions));
 
             return true;
         }

--- a/src/spool-dat-torrent.core/Configuration/TorrentServerProfile.cs
+++ b/src/spool-dat-torrent.core/Configuration/TorrentServerProfile.cs
@@ -6,7 +6,7 @@ namespace SpoolDatTorrent.Core.Configuration
 {
     public class TorrentServerProfile
     {
-        public string ClientType { get; set; } = "qBittorrent";
+        public BitTorrentClientType ClientType { get; set; } = BitTorrentClientType.QBittorrent;
         public string Host { get; set; } = "http://localhost:8080";
         public string Username { get; set; } = "admin";
         public string Password { get; set; } = string.Empty;

--- a/src/spool-dat-torrent.core/DTOs/ServerProfileDetails.cs
+++ b/src/spool-dat-torrent.core/DTOs/ServerProfileDetails.cs
@@ -1,3 +1,5 @@
+using SpoolDatTorrent.Core.Configuration;
+
 namespace SpoolDatTorrent.Core.DTOs
 {
     /// <summary>
@@ -6,7 +8,7 @@ namespace SpoolDatTorrent.Core.DTOs
     public class ServerProfileDetails
     {
         public string Name { get; set; } = string.Empty;
-        public string ClientType { get; set; } = string.Empty;
+        public BitTorrentClientType ClientType { get; set; }
         public string Host { get; set; } = string.Empty;
         public string Username { get; set; } = string.Empty;
         public bool HasApiKey { get; set; }

--- a/src/spool-dat-torrent.core/Services/BitTorrentClientFactory.cs
+++ b/src/spool-dat-torrent.core/Services/BitTorrentClientFactory.cs
@@ -41,7 +41,7 @@ namespace SpoolDatTorrent.Core.Services
                 profile = _settings.TorrentServers[firstProfile];
             }
 
-            // In the future, if profile.ClientType == "Deluge", you return a DelugeClient here
+            // In the future, if profile.ClientType == BitTorrentClientType.Deluge, you return a DelugeClient here
             var httpClient = _httpClientFactory.CreateClient($"qbit_{profileName}");
             httpClient.BaseAddress = new Uri(profile.Host);
 

--- a/src/spool-dat-torrent.web/Components/Shared/ServerProfileEditDialog.razor
+++ b/src/spool-dat-torrent.web/Components/Shared/ServerProfileEditDialog.razor
@@ -63,19 +63,17 @@
                               OnAdornmentClick="ToggleApiKeyVisibility"
                               AdornmentAriaLabel="Toggle API key visibility" />
             </MudItem>
-            @* Client Type dropdown hidden for now — only qBittorrent is implemented. Re-enable
-               when additional client types (e.g. Deluge) are supported. *@
-            @* <MudItem xs="12" md="6">
-                <MudSelect T="string" @bind-Value="Profile.ClientType"
+            <MudItem xs="12" md="6">
+                <MudSelect T="BitTorrentClientType" @bind-Value="Profile.ClientType"
                            @bind-Value:after="ScheduleSave"
                            Label="Client Type"
                            Variant="Variant.Outlined" FullWidth="true">
-                    @foreach (var type in BitTorrentClientTypes.All)
+                    @foreach (var type in Enum.GetValues<BitTorrentClientType>())
                     {
                         <MudSelectItem Value="@type">@type</MudSelectItem>
                     }
                 </MudSelect>
-            </MudItem> *@
+            </MudItem>
         </MudGrid>
 
         <MudDivider Class="my-3" />


### PR DESCRIPTION
#### PR Classification
Refactor to improve type safety and maintainability by replacing string-based BitTorrent client type representation with a strongly-typed enum.

#### PR Summary
This PR refactors the BitTorrent client type system from string constants to a strongly-typed enum, updating serialization and UI components accordingly for better type safety and extensibility.
- Replaces BitTorrentClientTypes static class and string constants with the BitTorrentClientType enum.
- Adds BitTorrentClientTypeConverter for System.Text.Json serialization/deserialization of the enum as strings.
- Updates SettingsManager to use the new converter for config files.
- Refactors DTOs and UI components (ServerProfileDetails, ServerProfileEditDialog) to use the enum for client type selection and display.
- Removes obsolete code related to the old string-based client type system.
